### PR TITLE
Configure dhcp6 server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 configure_apparmor: false
-dhcp_common_unknown_clients: true
+dhcp_common_unknown_clients: false
 dhcp_ddns_client_updates: true
 dhcp_ddns_update_static_leases: false
 dhcp_ddns_update_style: interim

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 configure_apparmor: false
-dhcp_common_unknown_clients: false
 dhcp_ddns_client_updates: true
+dhcp_ddns_unknown_clients: false
 dhcp_ddns_update_static_leases: false
 dhcp_ddns_update_style: interim
 dhcp_ddns_updates: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,8 @@
 - name: restart dhcpd
   service: name={{ dhcp_service }} state=restarted
 
+- name: restart dhcpd6
+  service: name={{ dhcp6_service }} state=restarted
+
 - name: restart apparmor
   service: name={{ apparmor_service }} state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,11 @@
   notify:
     - restart dhcpd
 
+- name: Generate dhcpd6.conf
+  template: src=dhcpd6.conf.j2 dest={{ dhcp6_server_config }}
+  notify:
+    - restart dhcpd6
+
 # Generate service configuration
 - name: Generate DHCP service conf
   template: src=service.conf.{{ ansible_os_family }}.j2 dest={{ dhcp_service_config }} owner=root group=root
@@ -51,3 +56,7 @@
 # Enable DHCP server
 - name: Start the dhcp services DHCP
   service: name={{ dhcp_service }} state=started enabled=yes
+
+# Enable DHCP6 server
+- name: Start the dhcp6 services DHCP
+  service: name={{ dhcp6_service }} state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     - restart dhcpd
 
 - name: Generate dhcpd6.conf
-  template: src=dhcpd6.conf.j2 dest={{ dhcp6_server_config }}
+  template: src=dhcpd6.conf.j2 dest={{ dhcp6_server_config }} owner=root group=root mode=0644 validate='/usr/sbin/dhcpd -t -6 -cf %s'
   notify:
     - restart dhcpd6
 

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -10,9 +10,6 @@ omapi-port {{ dhcp_omapi_port }};
 
 option domain-name "{{ dhcp_common_domain }}";
 {% endif %}
-{% if dhcp_common_domain_search is defined %}
-option domain-search {{ dhcp_common_domain_search }};
-{% endif %}
 {% if dhcp_common_nameservers is defined %}
 option domain-name-servers {{ dhcp_common_nameservers }};
 {% endif %}
@@ -23,12 +20,11 @@ default-lease-time {{ dhcp_common_default_lease_time }};
 max-lease-time {{ dhcp_common_max_lease_time }};
 {% endif %}
 
-{{ dhcp_common_unknown_clients | ternary("allow", "ignore") }} unknown-clients;
-
 # Dynamic DNS
 ddns-updates {{ dhcp_ddns_updates | ternary("on", "off") }};
 ddns-update-style {{ dhcp_ddns_update_style }};
 {{ dhcp_ddns_client_updates | ternary("allow", "ignore") }} client-updates;
+{{ dhcp_ddns_unknown_clients | ternary("allow", "ignore") }} unknown-clients;
 update-static-leases {{ dhcp_ddns_update_static_leases | ternary("on", "off") }};
 
 {% if dhcp_ddns_keys is defined %}

--- a/templates/dhcpd6.conf.j2
+++ b/templates/dhcpd6.conf.j2
@@ -1,0 +1,263 @@
+## dhcpd.conf
+{% if dhcp_use_ansible_managed %}# {{ ansible_managed }}{% endif %}
+# Do not edit manually
+
+{% if dhcp_omapi_port is defined %}
+omapi-port {{ dhcp_omapi_port }};
+{% endif %}
+# option definitions common to all supported networks...
+{% if dhcp_common_domain is defined %}
+option domain-name "{{ dhcp_common_domain }}";
+{% endif %}
+{% if dhcp_common_default_lease_time is defined %}
+default-lease-time {{ dhcp_common_default_lease_time }};
+{% endif %}
+{% if dhcp_common_max_lease_time is defined %}
+max-lease-time {{ dhcp_common_max_lease_time }};
+{% endif %}
+
+# Dynamic DNS
+{{ dhcp_ddns_unknown_clients | ternary("allow", "ignore") }} unknown-clients;
+
+{% if dhcp_ddns_keys is defined %}
+{% for key in dhcp_ddns_keys %}
+key {{ key.name }} {
+  algorithm hmac-md5;
+  secret {{ key.value }};
+}
+
+{% endfor %}
+{% endif %}
+{% if dhcp_ddns_zones is defined %}
+{% for zone in dhcp_ddns_zones %}
+zone {{ zone.name }}. {
+  primary {{ zone.primary }};
+  key {{ zone.key }};
+}
+
+{% endfor %}
+{% endif %}
+{% if dhcp_common_authoritative is defined %}
+# If this DHCP server is the official DHCP server for the local
+# network, the authoritative directive should be uncommented.
+authoritative;
+{% endif %}
+{% if dhcp_common_log_facility is defined %}
+
+# Use this to send dhcp log messages to a different log file (you also
+# have to hack syslog.conf to complete the redirection).
+log-facility {{ dhcp_common_log_facility }};
+{% endif %}
+{% if dhcp_common_options is defined %}
+
+{% if dhcp_common_enable_pxe_boot %}
+filename "{{ dhcp_common_pxe_boot_file }}";
+next-server {{ dhcp_common_pxe_boot_server }};
+{% endif %}
+
+#DHCP options
+{% for o in dhcp_common_options %}
+option {{ o }};
+{% endfor %}
+{% endif %}
+{% if dhcp_common_parameters is defined %}
+
+#DHCP parameters
+{% for p in dhcp6_common_parameters %}
+{{ p }};
+{% endfor %}
+{% endif %}
+{% if dhcp_classes is defined %}
+
+# Classes
+{% for c in dhcp_classes %}
+class "{{ c.name }}" {
+  {{ c.rule }};
+{% if c.options is defined %}
+{% for i in c.options %}
+  option {{ i.opt }};
+{% endfor %}
+{% endif %}
+}
+{% endfor %}
+{% endif %}
+
+{% if dhcp_hosts is defined %}
+# Hosts
+{% for h in dhcp_hosts %}
+host {{ h.name }} {
+  hardware ethernet {{ h.mac_address }};
+  ddns-hostname {{ h.name }};
+{% if h.fixed_address is defined %}
+  fixed-address {{ h.fixed_address }};
+{% endif %}
+{% if h.routers is defined %}
+  option routers {{ h.routers }};
+{% endif %}
+{% if h.broadcast_address is defined %}
+  option broadcast-address {{ h.broadcast_address }};
+{% endif %}
+{% if h.domain_nameservers is defined %}
+  option domain-name-servers {{ h.domain_nameservers }};
+{% endif %}
+{% if h.domain_name is defined %}
+  option domain-name "{{ h.domain_name }}";
+{% endif %}
+{% if h.default_lease_time is defined %}
+  default-lease-time {{ h.default_lease_time }};
+{% endif %}
+{% if h.max_lease_time is defined %}
+  max-lease-time {{ h.max_lease_time }};
+{% endif %}
+{% if h.parameters is defined %}
+{% for p in h.parameters %}
+  {{ p }};
+{% endfor %}
+{% endif %}
+}
+{% endfor %}
+{% endif %}
+
+{% if dhcp6_subnets is defined %}
+# Subnets
+{% for s in dhcp6_subnets %}
+subnet6 {{ s.base }} {
+{% if s.interface is defined %}
+  interface {{ s.interface }};
+{% endif %}
+{% if s.range_start is defined %}
+  range {{ s.range_start }} {{ s.range_end }};
+{% endif %}
+{% if s.routers is defined %}
+  option routers {{ s.routers }};
+{% endif %}
+{% if s.broadcast_address is defined %}
+  option broadcast-address {{ s.broadcast_address }};
+{% endif %}
+{% if s.domain_nameservers is defined %}
+  option dhcp6.name-servers {{ s.domain_nameservers }};
+{% endif %}
+{% if s.domain_name is defined %}
+  option dhcp.domain-search "{{ s.domain_name }}";
+{% endif %}
+{% if s.ntp_servers is defined %}
+  option ntp-servers {{ s.ntp_servers }};
+{% endif %}
+{% if s.default_lease_time is defined %}
+  default-lease-time {{ s.default_lease_time }};
+{% endif %}
+{% if s.max_lease_time is defined %}
+  max-lease-time {{ s.max_lease_time }};
+{% endif %}
+{% if s.pools is defined %}
+{% for p in s.pools %}
+  pool {
+{% if p.rule is defined %}
+    {{ p.rule }};
+{% endif %}
+    range {{ p.range_start }} {{ p.range_end }};
+{% if p.parameters is defined %}
+{% for param in p.parameters %}
+    {{ param }};
+{% endfor %}
+{% endif %}
+  }
+{% endfor %}
+{% endif %}
+{% if s.parameters is defined %}
+{% for p in s.parameters %}
+  {{ p }};
+{% endfor %}
+{% endif %}
+}
+{% endfor %}
+{% endif %}
+
+{% if dhcp_shared_networks is defined %}
+# Shared networks
+{% for n in dhcp_shared_networks %}
+shared-network {{ n.name }} {
+{% if n.interface is defined %}
+  interface "{{ n.interface }}";
+{% endif %}
+{% for s in n.subnets %}
+  subnet {{ s.base }} netmask {{ s.netmask }} {
+{% if s.range_start is defined %}
+    range {{ s.range_start }} {{ s.range_end }};
+{% endif %}
+{% if s.routers is defined %}
+    option routers {{ s.routers }};
+{% endif %}
+{% if s.broadcast_address is defined %}
+    option broadcast-address {{ s.broadcast_address }};
+{% endif %}
+{% if s.domain_nameservers is defined %}
+    option domain-name-servers {{ s.domain_nameservers }};
+{% endif %}
+{% if s.domain_name is defined %}
+    option domain-name "{{ s.domain_name }}";
+{% endif %}
+{% if s.ntp_servers is defined %}
+    option ntp-servers {{ s.ntp_servers }};
+{% endif %}
+{% if s.default_lease_time is defined %}
+    default-lease-time {{ s.default_lease_time }};
+{% endif %}
+{% if s.max_lease_time is defined %}
+    max-lease-time {{ s.max_lease_time }};
+{% endif %}
+{% if s.pools is defined %}
+{% for p in s.pools %}
+    pool {
+{% if p.rule is defined %}
+      {{ p.rule }};
+{% endif %}
+      range {{ p.range_start }} {{ p.range_end }};
+{% if p.parameters is defined %}
+{% for param in p.parameters %}
+      {{ param }};
+{% endfor %}
+{% endif %}
+    }
+{% endfor %}
+{% endif %}
+{% if s.parameters is defined %}
+{% for param in s.parameters %}
+    {{ param }};
+{% endfor %}
+{% endif %}
+  }
+{% endfor %}
+{% if n.pools is defined %}
+{% for p in n.pools %}
+  pool {
+    {{ p.rule }};
+    range {{ p.range_start }} {{ p.range_end }};
+{% if p.parameters is defined %}
+{% for param in p.parameters %}
+    {{ param }};
+{% endfor %}
+{% endif %}
+  }
+{% endfor %}
+{% endif %}
+{% if n.parameters is defined %}
+{% for p in n.parameters %}
+  {{ p }};
+{% endfor %}
+{% endif %}
+}
+{% endfor %}
+{% endif %}
+
+{% if dhcp_ifelse is defined %}
+# If else clauses
+{% for ie in dhcp_ifelse %}
+if {{ ie.condition }} {
+    {{ ie.val }}
+}{% if ie.else is defined %}{% for e in ie.else %} else {
+    {{ e.val }}
+}{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,5 +2,7 @@
 dhcp_server_package: dhcp
 dhcp_server_config: /etc/dhcp/dhcpd.conf
 dhcp_service: dhcpd
+dhcp6_server_config: /etc/dhcp/dhcpd6.conf
+dhcp6_service: dhcpd6
 dhcp_service_config: /etc/sysconfig/dhcpd
 apparmor_service: apparmor


### PR DESCRIPTION
We are going to have another gateway server in ePouta environment.
In this gateway servers we need to configure dhcp6 servers for the 
ipmi networks.

CCCP-3987